### PR TITLE
Add a simple Dockerfile to rmbt-server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+rmbtd
+random

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+#####
+FROM alpine AS build-env
+RUN apk add --no-cache util-linux-dev gcc autoconf automake make openssl-dev musl-dev
+
+COPY . /work
+WORKDIR /work
+
+RUN sed -i 's|#define CHECK_TOKEN 1|#define CHECK_TOKEN 0|' config.h
+RUN make server-prod
+
+#####
+FROM alpine
+ARG GIT_VERSION
+LABEL version=${GIT_VERSION:-unknown}
+RUN apk add --no-cache libuuid json-c openssl
+COPY --from=build-env /work/rmbtd /bin/rmbtd
+COPY docker-entrypoint.sh /
+VOLUME /config
+EXPOSE 8081 8082
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -8,11 +8,24 @@ RMBT Test Server
 Docker
 ------
 
+### Server
+
 To simply run the server (**with diabled token check!**) with Docker, run:
 
 ```
 docker run -v rmbtd-config:/config -p 8081-8082:8081-8082 lwimmer/rmbt-server
 ```
+
+### Client
+
+`rmbt-client` can be easily used as a CLI measurement client in Docker:
+
+```
+docker run lwimmer/rmbt-client -h <server hostname> -p <server port> -s ''
+```
+
+For more information see https://github.com/lwimmer/rmbt-client.
+
 
 Prerequisites
 -------------

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Docker
 To simply run the server (with diabled token check!) with Docker, run:
 
 ```
-docker run -v rmbtd-config:/config -p 8081-8082:8081-8082 rmbt-server
+docker run -v rmbtd-config:/config -p 8081-8082:8081-8082 lwimmer/rmbt-server
 ```
 
 Prerequisites

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ RMBT Test Server
 Docker
 ------
 
-To simply run the server (with diabled token check!) with Docker, run:
+To simply run the server (**with diabled token check!**) with Docker, run:
 
 ```
 docker run -v rmbtd-config:/config -p 8081-8082:8081-8082 lwimmer/rmbt-server

--- a/README.md
+++ b/README.md
@@ -5,6 +5,15 @@ RMBT Test Server
   the RMBT protocol. Clients can communicate either directly via TCP sockets or based on 
   the WebSocket protocol.
 
+Docker
+------
+
+To simply run the server (with diabled token check!) with Docker, run:
+
+```
+docker run -v rmbtd-config:/config -p 8081-8082:8081-8082 rmbt-server
+```
+
 Prerequisites
 -------------
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+[ -e /config/secret.key ] || dd if=/dev/urandom | tr -dc A-Za-z0-9 | head -c100 | awk '{print $$1 " auto-generated key"}' > /config/secret.key
+[ -e /config/server.crt -a -e /config/server.key ] || openssl req -x509 -newkey rsa:4096 -keyout /config/server.key -out /config/server.crt -nodes -subj '/CN=localhost' -sha256 -days 10000 
+[ -e /config/random ] || dd if=/dev/urandom of=/config/random bs=1M count=100
+cd /config
+exec rmbtd -c /config/server.crt -k /config/server.key -l 8081 -L 8082 "$@"

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# File needs to be called /hooks/build relative to the Dockerfile.
+# $IMAGE_NAME var is injected into the build so the tag is correct.
+
+echo "Build hook running"
+docker build --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
+             --build-arg "GIT_VERSION=`git describe --abbrev=9 --dirty --always --tags --long 2> /dev/null`" \
+             -t $IMAGE_NAME .


### PR DESCRIPTION
This PR adds a simple Dockerfile to `rmbt-server`, to be able to quickly and easily run it in Docker.

For ease of use, the token check on the server has been disabled.